### PR TITLE
Naming pm2 process in order to not delete all but the application itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node.js base app for RedRadix",
   "main": "index.js",
   "engines" : {
-    "node" : ">=4.2.4",
+    "node" : ">=4.3.0",
     "npm" : ">=2.14"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   },
   "scripts": {
     "start": "npm run migrate:dev && npm run watch && npm run logs",
-    "watch": "npm run migrate:dev && ./node_modules/.bin/pm2 start index.js --watch -f",
+    "watch": "npm run migrate:dev && ./node_modules/.bin/pm2 start index.js --watch -f --name nodebaseapp",
     "logs": "./node_modules/.bin/pm2 logs",
-    "stop": "./node_modules/.bin/pm2 delete all",
+    "stop": "./node_modules/.bin/pm2 delete nodebaseapp",
     "migrate:dev": "knex --knexfile ./config/knexfile.js migrate:latest",
     "migrate:test": "knex --env test --knexfile ./config/knexfile.js migrate:latest",
     "migrate": "npm run migrate:dev && npm run migrate:test",


### PR DESCRIPTION
I think @acontreras89 was in charge of the scripts part of this baseApp. This is a fix that probably has already came up to your minds.

Instead of deleting all pm2 processes, this way gives a name to the process of the app and deletes only that process when running `npm stop`.

However, this name has to be changed for each new app as well.
